### PR TITLE
Unlink CQv2,1 CQv1,2 and DQv2,1 DQv1,2

### DIFF
--- a/Dynamic/sparsity_constraints.m
+++ b/Dynamic/sparsity_constraints.m
@@ -10,8 +10,8 @@ I     = eye(n);
 % Defines CQ and DQ both as symbolic variables and sdpvar variables
 CQs   = sym('CQ',[m n*N]); %symbolic
 DQs   = sym('DQ',[m n]);
-CQv   = sdpvar(m,n*N);     %variable      
-DQv   = sdpvar(m,n);
+CQv   = sdpvar(m,n*N,'full');     %variable      
+DQv   = sdpvar(m,n,'full');
 
 %Write the finite-dimensional approximation of the Youla parameter as per
 %(16) of [0]


### PR DESCRIPTION
unless specified as 'full', CQv and DQv will be symmetric by default, adding unwanted additional constraints. This is the case if m == n (and for CQ additionally N = 1).